### PR TITLE
Bugfix for platform-specific issue

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:thc/views/home/home_screen.dart';
 import 'package:thc/views/settings/settings.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await loadFromLocalStorage();
   runApp(const App());
 }


### PR DESCRIPTION
Currently, `main()` is set up as follows:

```dart
void main() async {
  await loadFromLocalStorage();
  runApp(const App());
}
```

This works fine for Windows but breaks for any other platform. We need to add the following call:

```dart
void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  await loadFromLocalStorage();
  runApp(const App());
}
```