### PR TITLE
Livestream list view

### DIFF
--- a/lib/views/home/home_screen.dart
+++ b/lib/views/home/home_screen.dart
@@ -7,7 +7,7 @@ import 'package:thc/models/enum_widget.dart';
 import 'package:thc/models/local_storage.dart';
 import 'package:thc/models/user.dart';
 import 'package:thc/views/create_livestream/create_livestream.dart';
-import 'package:thc/views/manage_schedule/manage_schedule.dart';
+import 'package:thc/views/schedule/schedule.dart';
 import 'package:thc/views/manage_surveys/manage_surveys.dart';
 import 'package:thc/views/manage_users/manage_users.dart';
 import 'package:thc/views/profile/profile.dart';
@@ -26,7 +26,7 @@ enum NavBarButton with StatelessEnum {
   schedule(
     outlined: Icon(Icons.calendar_month_outlined),
     filled: Icon(Icons.calendar_month),
-    screen: ManageSchedule(),
+    screen: Schedule(),
   ),
 
   /// A place for admins to edit surveys, and view a summary of survey responses.

--- a/lib/views/manage_schedule/manage_schedule.dart
+++ b/lib/views/manage_schedule/manage_schedule.dart
@@ -7,6 +7,6 @@ class ManageSchedule extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FunPlaceholder('Manage Schedule', color: context.colorScheme.secondary);
+    return const FunPlaceholder('schedule a livestream!', color: ThcColors.dullBlue);
   }
 }

--- a/lib/views/manage_schedule/manage_schedule.dart
+++ b/lib/views/manage_schedule/manage_schedule.dart
@@ -7,6 +7,6 @@ class ManageSchedule extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const FunPlaceholder('schedule a livestream!', color: ThcColors.dullBlue);
+    return FunPlaceholder('Manage Schedule', color: context.colorScheme.secondary);
   }
 }

--- a/lib/views/schedule/schedule.dart
+++ b/lib/views/schedule/schedule.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:thc/models/navigator.dart';
+import 'package:thc/models/theme.dart';
+import 'package:thc/models/user.dart';
+import 'package:thc/views/manage_schedule/manage_schedule.dart';
+
+class Schedule extends StatelessWidget {
+  const Schedule({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Livestream Schedule'),
+        backgroundColor: ThcColors.darkBlue,
+        actions: [
+          Visibility(
+            visible: userType.isAdmin,
+            child: IconButton(
+              icon: const Icon(Icons.add), // Choose your desired icon
+              onPressed: () {
+                // Add your onPressed callback function here
+                // This function will be called when the icon button is clicked
+                navigator.push(const ManageSchedule());
+              },
+            ),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            // First Header
+            Container(
+              margin: const EdgeInsets.only(top: 16.0),
+              padding: const EdgeInsets.all(16.0),
+              child: const Text(
+                'Active Livestreams',
+                style: TextStyle(
+                  fontSize: 24.0,
+                  color: ThcColors.darkBlue,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            // First ListView inside a Card
+            Container(
+              margin: const EdgeInsets.all(16.0),
+              child: const Column(
+                children: [
+                  Card(
+                    color: ThcColors.green,
+                    margin: EdgeInsets.all(8.0), // Set margins for all sides
+                    child: ListTile(
+                      leading: FlutterLogo(size: 56.0),
+                      title: Text('Active Livestream'),
+                      subtitle: Text('April 3, 2024 12:00PM EST'),
+                    ),
+                  ),
+                  // Add more ListTiles as needed
+                ],
+              ),
+            ),
+            // Second Header
+            Container(
+              padding: const EdgeInsets.all(16.0),
+              child: const Text(
+                'Upcoming Livestreams',
+                style: TextStyle(
+                  fontSize: 24.0,
+                  color: ThcColors.darkBlue,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            // Second ListView inside a Card
+            Container(
+              margin: const EdgeInsets.all(16.0),
+              child: const Column(
+                children: [
+                  Card(
+                    color: ThcColors.green,
+                    margin: EdgeInsets.all(8.0), // Set margins for all sides
+                    child: ListTile(
+                      leading: FlutterLogo(size: 56.0),
+                      title: Text('Upcoming Livestream A'),
+                      subtitle: Text('June 5, 2024 7:00PM EST'),
+                    ),
+                  ),
+                  Card(
+                    color: ThcColors.green,
+                    margin: EdgeInsets.all(8.0), // Set margins for all sides
+                    child: ListTile(
+                      leading: FlutterLogo(size: 56.0),
+                      title: Text('Upcoming Livestream B'),
+                      subtitle: Text('June 10, 2024 7:00PM EST'),
+                    ),
+                  ),
+                  Card(
+                    color: ThcColors.green,
+                    margin: EdgeInsets.all(8.0), // Set margins for all sides
+                    child: ListTile(
+                      leading: FlutterLogo(size: 56.0),
+                      title: Text('Upcoming Livestream C'),
+                      subtitle: Text('June 15, 2024 12:00PM EST'),
+                    ),
+                  ),
+                  Card(
+                    color: ThcColors.green,
+                    margin: EdgeInsets.all(8.0), // Set margins for all sides
+                    child: ListTile(
+                      leading: FlutterLogo(size: 56.0),
+                      title: Text('Upcoming Livestream D'),
+                      subtitle: Text('June 20, 2024 2:00PM EST'),
+                    ),
+                  ),
+                  Card(
+                    color: ThcColors.green,
+                    margin: EdgeInsets.all(8.0), // Set margins for all sides
+                    child: ListTile(
+                      leading: FlutterLogo(size: 56.0),
+                      title: Text('Upcoming Livestream E'),
+                      subtitle: Text('June 25, 2024 4:00PM EST'),
+                    ),
+                  ),
+                  // Add more ListTiles as needed
+                ],
+              ),
+            ),
+            // Add more headers and cards with ListViews as needed
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Created Schedule screen, added list tiles for upcoming/active livestreams. Added an icon to the top to link to the Manage Schedule screen. 

As always, any and all feedback is welcome, thanks!

Ticket: https://www.notion.so/Dev-Team-Backlog-61374ba6710c4e7ca03499d17c379425?p=8e285b060ab547ba84da6cc71a859a6d&pm=s

![Screenshot 2024-04-03 at 9 13 00 AM](https://github.com/theheartcenter-one/thc/assets/11184478/890a419b-6344-4315-bd30-f90adeb8b7a5)

